### PR TITLE
Replace call_owm with call_api

### DIFF
--- a/flexmeasures_weather/cli/tests/test_get_forecasts.py
+++ b/flexmeasures_weather/cli/tests/test_get_forecasts.py
@@ -4,7 +4,7 @@ from flexmeasures.data.models.time_series import TimedBelief
 
 from ..commands import collect_weather_data
 from ...utils import weather
-from .utils import mock_owm_response
+from .utils import mock_api_response
 
 
 """
@@ -24,7 +24,7 @@ def test_get_weather_forecasts_to_db(
     weather_station = wind_sensor.generic_asset
 
     monkeypatch.setitem(app.config, "WEATHERAPI_KEY", "dummy")
-    monkeypatch.setattr(weather, "call_openweatherapi", mock_owm_response)
+    monkeypatch.setattr(weather, "call_api", mock_api_response)
 
     runner = app.test_cli_runner()
     result = runner.invoke(
@@ -54,7 +54,7 @@ def test_get_weather_forecasts_no_close_sensors(
     weather_station = add_weather_sensors_fresh_db["wind"].generic_asset
 
     monkeypatch.setitem(app.config, "WEATHERAPI_KEY", "dummy")
-    monkeypatch.setattr(weather, "call_openweatherapi", mock_owm_response)
+    monkeypatch.setattr(weather, "call_api", mock_api_response)
 
     runner = app.test_cli_runner()
     with caplog.at_level(logging.WARNING):

--- a/flexmeasures_weather/cli/tests/utils.py
+++ b/flexmeasures_weather/cli/tests/utils.py
@@ -12,7 +12,7 @@ def cli_params_from_dict(d) -> List[str]:
     return cli_params
 
 
-def mock_owm_response(api_key, location):
+def mock_api_response(api_key, location):
     mock_date = datetime.now()
     mock_date_tz_aware = as_server_time(
         datetime.fromtimestamp(mock_date.timestamp(), tz=get_timezone())


### PR DESCRIPTION
I make the tests call the general `call_api` function instead of the specific `call_openweatherapi`. I also generalized the name of the mock response to be called `mock_api_response`.

This is to address the issue #4.

Closes #4 