### PR TITLE
Feat/register account for data source

### DIFF
--- a/flexmeasures_weather/cli/commands.py
+++ b/flexmeasures_weather/cli/commands.py
@@ -162,7 +162,11 @@ def collect_weather_data(location, asset_id, store_in_db, num_cells, method, reg
     a geometrical grid (See the --location parameter).
     """
 
-    api_key = str(current_app.config.get("WEATHERAPI_KEY", ""))
+    api_key = str(
+        current_app.config.get(
+            "WEATHERAPI_KEY", current_app.config.get("OPENWEATHERMAP_API_KEY", "")
+        )
+    )
     if api_key == "":
         raise Exception("[FLEXMEASURES-WEATHER] Setting WEATHERAPI_KEY not available.")
     if asset_id is not None:

--- a/flexmeasures_weather/cli/schemas/weather_sensor.py
+++ b/flexmeasures_weather/cli/schemas/weather_sensor.py
@@ -28,7 +28,7 @@ class WeatherSensorSchema(Schema):
     )
 
     @validates("name")
-    def validate_name_is_supported(self, name: str):
+    def validate_name_is_supported(self, name: str, **kwargs):
         if get_supported_sensor_spec(name):
             return
         raise ValidationError(
@@ -36,7 +36,7 @@ class WeatherSensorSchema(Schema):
         )
 
     @validates("timezone")
-    def validate_timezone(self, timezone: str):
+    def validate_timezone(self, timezone: str, **kwargs):
         try:
             pytz.timezone(timezone)
         except pytz.UnknownTimeZoneError:

--- a/flexmeasures_weather/cli/tests/test_get_forecasts.py
+++ b/flexmeasures_weather/cli/tests/test_get_forecasts.py
@@ -60,7 +60,10 @@ def test_get_weather_forecasts_no_close_sensors(
     with caplog.at_level(logging.WARNING):
         result = runner.invoke(
             collect_weather_data,
-            ["--location", f"{weather_station.latitude-5},{weather_station.longitude}"],
+            [
+                "--location",
+                f"{weather_station.latitude - 5},{weather_station.longitude}",
+            ],
         )
         print(result.output)
         assert "Reported task get-weather-forecasts status as True" in result.output

--- a/flexmeasures_weather/utils/modeling.py
+++ b/flexmeasures_weather/utils/modeling.py
@@ -34,7 +34,7 @@ def get_or_create_weather_account() -> Account:
 
 
 def get_or_create_owm_data_source() -> Source:
-    """Make sure we have an data source"""
+    """Make sure we have a raw weather provider data source of type "market"."""
     source_kwargs = dict(
         source=current_app.config.get(
             "WEATHER_DATA_SOURCE_NAME", DEFAULT_DATA_SOURCE_NAME

--- a/flexmeasures_weather/utils/modeling.py
+++ b/flexmeasures_weather/utils/modeling.py
@@ -38,12 +38,12 @@ def get_or_create_weather_account() -> Account:
 
 
 def get_or_create_owm_data_source() -> Source:
-    """Make sure we have a raw weather provider data source of type "market"."""
+    """Make sure we have a weather provider data source of the configured type."""
     source_kwargs = dict(
         source=current_app.config.get(
             "WEATHER_DATA_SOURCE_NAME", DEFAULT_DATA_SOURCE_NAME
         ),
-        source_type="market",
+        source_type=SOURCE_TYPE,
         flush=False,
     )
     if SUPPORTS_SOURCE_ACCOUNT:

--- a/flexmeasures_weather/utils/modeling.py
+++ b/flexmeasures_weather/utils/modeling.py
@@ -1,9 +1,8 @@
-import inspect
 from packaging import version
 
 from flask import current_app
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
-from flexmeasures import Account, Source, __version__ as flexmeasures_version
+from flexmeasures import Source, __version__ as flexmeasures_version
 from flexmeasures.data import db
 from flexmeasures.data.services.data_sources import get_or_create_source
 
@@ -17,13 +16,22 @@ if version.parse(flexmeasures_version) < version.parse("0.13"):
 else:
     SOURCE_TYPE = "forecaster"
 
-SUPPORTS_SOURCE_ACCOUNT = (
-    "account" in inspect.signature(get_or_create_source).parameters
-)
+FM_SUPPORTS_ACCOUNT_LINKED_SOURCES = version.parse(
+    flexmeasures_version
+) >= version.parse("0.32")
+
+if FM_SUPPORTS_ACCOUNT_LINKED_SOURCES:
+    from flexmeasures import Account
+else:
+    Account = None
 
 
-def get_or_create_weather_account() -> Account:
+def get_or_create_weather_account():
     """Make sure we have an account for the weather provider service."""
+    if Account is None:
+        raise RuntimeError(
+            "FlexMeasures Account model is unavailable before FlexMeasures 0.32."
+        )
     account_name = current_app.config.get(
         "WEATHER_DATA_SOURCE_NAME", DEFAULT_DATA_SOURCE_NAME
     )
@@ -46,7 +54,7 @@ def get_or_create_owm_data_source() -> Source:
         source_type=SOURCE_TYPE,
         flush=False,
     )
-    if SUPPORTS_SOURCE_ACCOUNT:
+    if FM_SUPPORTS_ACCOUNT_LINKED_SOURCES:
         source_kwargs["account"] = get_or_create_weather_account()
     return get_or_create_source(**source_kwargs)
 
@@ -60,7 +68,7 @@ def get_or_create_owm_data_source_for_derived_data() -> Source:
         source_type=SOURCE_TYPE,
         flush=False,
     )
-    if SUPPORTS_SOURCE_ACCOUNT:
+    if FM_SUPPORTS_ACCOUNT_LINKED_SOURCES:
         source_kwargs["account"] = get_or_create_weather_account()
     return get_or_create_source(**source_kwargs)
 

--- a/flexmeasures_weather/utils/modeling.py
+++ b/flexmeasures_weather/utils/modeling.py
@@ -1,8 +1,9 @@
+import inspect
 from packaging import version
 
 from flask import current_app
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
-from flexmeasures import Source, __version__ as flexmeasures_version
+from flexmeasures import Account, Source, __version__ as flexmeasures_version
 from flexmeasures.data import db
 from flexmeasures.data.services.data_sources import get_or_create_source
 
@@ -17,26 +18,47 @@ else:
     SOURCE_TYPE = "forecaster"
 
 
+def get_or_create_weather_account() -> Account:
+    """Make sure we have an account for the weather provider service."""
+    account_name = current_app.config.get(
+        "WEATHER_DATA_SOURCE_NAME", DEFAULT_DATA_SOURCE_NAME
+    )
+    weather_account = Account.query.filter(
+        Account.name == account_name,
+    ).one_or_none()
+    if weather_account is None:
+        weather_account = Account(name=account_name)
+        db.session.add(weather_account)
+        db.session.flush()
+    return weather_account
+
+
 def get_or_create_owm_data_source() -> Source:
     """Make sure we have an data source"""
-    return get_or_create_source(
+    source_kwargs = dict(
         source=current_app.config.get(
             "WEATHER_DATA_SOURCE_NAME", DEFAULT_DATA_SOURCE_NAME
         ),
-        source_type=SOURCE_TYPE,
+        source_type="market",
         flush=False,
     )
+    if "account" in inspect.signature(get_or_create_source).parameters:
+        source_kwargs["account"] = get_or_create_weather_account()
+    return get_or_create_source(**source_kwargs)
 
 
 def get_or_create_owm_data_source_for_derived_data() -> Source:
     owm_source_name = current_app.config.get(
         "WEATHER_DATA_SOURCE_NAME", DEFAULT_DATA_SOURCE_NAME
     )
-    return get_or_create_source(
+    source_kwargs = dict(
         source=f"FlexMeasures {owm_source_name}",
         source_type=SOURCE_TYPE,
         flush=False,
     )
+    if "account" in inspect.signature(get_or_create_source).parameters:
+        source_kwargs["account"] = get_or_create_weather_account()
+    return get_or_create_source(**source_kwargs)
 
 
 def get_or_create_weather_station_type() -> GenericAssetType:

--- a/flexmeasures_weather/utils/modeling.py
+++ b/flexmeasures_weather/utils/modeling.py
@@ -17,6 +17,10 @@ if version.parse(flexmeasures_version) < version.parse("0.13"):
 else:
     SOURCE_TYPE = "forecaster"
 
+SUPPORTS_SOURCE_ACCOUNT = (
+    "account" in inspect.signature(get_or_create_source).parameters
+)
+
 
 def get_or_create_weather_account() -> Account:
     """Make sure we have an account for the weather provider service."""
@@ -42,7 +46,7 @@ def get_or_create_owm_data_source() -> Source:
         source_type="market",
         flush=False,
     )
-    if "account" in inspect.signature(get_or_create_source).parameters:
+    if SUPPORTS_SOURCE_ACCOUNT:
         source_kwargs["account"] = get_or_create_weather_account()
     return get_or_create_source(**source_kwargs)
 
@@ -56,7 +60,7 @@ def get_or_create_owm_data_source_for_derived_data() -> Source:
         source_type=SOURCE_TYPE,
         flush=False,
     )
-    if "account" in inspect.signature(get_or_create_source).parameters:
+    if SUPPORTS_SOURCE_ACCOUNT:
         source_kwargs["account"] = get_or_create_weather_account()
     return get_or_create_source(**source_kwargs)
 

--- a/flexmeasures_weather/utils/tests/test_modeling.py
+++ b/flexmeasures_weather/utils/tests/test_modeling.py
@@ -6,6 +6,7 @@ from flexmeasures import Account
 
 from flexmeasures_weather import DEFAULT_WEATHER_STATION_NAME
 from flexmeasures_weather.utils.modeling import (
+    SOURCE_TYPE,
     get_or_create_owm_data_source,
     get_or_create_owm_data_source_for_derived_data,
     get_or_create_weather_account,
@@ -47,7 +48,7 @@ def test_get_or_create_owm_data_source_registers_market_source_on_weather_accoun
 def test_get_or_create_owm_data_source_for_derived_data_uses_weather_account(fresh_db):
     derived_data_source = get_or_create_owm_data_source_for_derived_data()
 
-    assert derived_data_source.type == "forecaster"
+    assert derived_data_source.type == SOURCE_TYPE
     if (
         "account"
         in inspect.signature(
@@ -110,5 +111,5 @@ def test_get_or_create_owm_derived_data_source_passes_weather_account_when_suppo
 
     data_source = get_or_create_owm_data_source_for_derived_data()
 
-    assert data_source.type == "forecaster"
+    assert data_source.type == SOURCE_TYPE
     assert captured_kwargs["account"].name == "Weather"

--- a/flexmeasures_weather/utils/tests/test_modeling.py
+++ b/flexmeasures_weather/utils/tests/test_modeling.py
@@ -5,7 +5,7 @@ from flexmeasures import Asset
 from flexmeasures import Account
 
 import flexmeasures_weather.utils.modeling as modeling
-from flexmeasures_weather import DEFAULT_WEATHER_STATION_NAME
+from flexmeasures_weather import DEFAULT_DATA_SOURCE_NAME, DEFAULT_WEATHER_STATION_NAME
 from flexmeasures_weather.utils.modeling import (
     SOURCE_TYPE,
     get_or_create_owm_data_source,
@@ -24,7 +24,7 @@ def test_creating_two_weather_stations(fresh_db):
 def test_get_or_create_weather_account(fresh_db):
     weather_account = get_or_create_weather_account()
 
-    assert weather_account.name == "Weather"
+    assert weather_account.name == DEFAULT_DATA_SOURCE_NAME
     assert Account.query.filter(Account.name == weather_account.name).count() == 1
 
 

--- a/flexmeasures_weather/utils/tests/test_modeling.py
+++ b/flexmeasures_weather/utils/tests/test_modeling.py
@@ -1,10 +1,114 @@
+import inspect
+from types import SimpleNamespace
+
 from flexmeasures import Asset
+from flexmeasures import Account
 
 from flexmeasures_weather import DEFAULT_WEATHER_STATION_NAME
-from flexmeasures_weather.utils.modeling import get_or_create_weather_station
+from flexmeasures_weather.utils.modeling import (
+    get_or_create_owm_data_source,
+    get_or_create_owm_data_source_for_derived_data,
+    get_or_create_weather_account,
+    get_or_create_weather_station,
+)
 
 
 def test_creating_two_weather_stations(fresh_db):
     get_or_create_weather_station(50, 40)
     get_or_create_weather_station(40, 50)
     assert Asset.query.filter(Asset.name == DEFAULT_WEATHER_STATION_NAME).count() == 2
+
+
+def test_get_or_create_weather_account(fresh_db):
+    weather_account = get_or_create_weather_account()
+
+    assert weather_account.name == "Weather"
+    assert Account.query.filter(Account.name == weather_account.name).count() == 1
+
+
+def test_get_or_create_owm_data_source_registers_market_source_on_weather_account(
+    fresh_db,
+):
+    data_source = get_or_create_owm_data_source()
+
+    assert data_source.type == "market"
+    if (
+        "account"
+        in inspect.signature(
+            get_or_create_owm_data_source.__globals__["get_or_create_source"]
+        ).parameters
+    ):
+        assert data_source.account is not None
+        assert data_source.account.name == data_source.name
+    else:
+        assert Account.query.filter(Account.name == data_source.name).count() == 0
+
+
+def test_get_or_create_owm_data_source_for_derived_data_uses_weather_account(fresh_db):
+    derived_data_source = get_or_create_owm_data_source_for_derived_data()
+
+    assert derived_data_source.type == "forecaster"
+    if (
+        "account"
+        in inspect.signature(
+            get_or_create_owm_data_source.__globals__["get_or_create_source"]
+        ).parameters
+    ):
+        assert derived_data_source.account is not None
+        assert derived_data_source.account.name == "Weather"
+    else:
+        assert Account.query.filter(Account.name == "Weather").count() == 0
+
+
+def test_get_or_create_owm_data_source_passes_weather_account_when_supported(
+    fresh_db, monkeypatch
+):
+    captured_kwargs = {}
+
+    def fake_get_or_create_source(source, source_type, account, flush):
+        captured_kwargs.update(
+            dict(
+                source=source,
+                source_type=source_type,
+                account=account,
+                flush=flush,
+            )
+        )
+        return SimpleNamespace(type=source_type, account=account)
+
+    monkeypatch.setattr(
+        "flexmeasures_weather.utils.modeling.get_or_create_source",
+        fake_get_or_create_source,
+    )
+
+    data_source = get_or_create_owm_data_source()
+
+    assert data_source.type == "market"
+    assert captured_kwargs["account"].name == "Weather"
+
+
+def test_get_or_create_owm_derived_data_source_passes_weather_account_when_supported(
+    fresh_db, monkeypatch
+):
+    captured_kwargs = {}
+
+    def fake_get_or_create_source(source, source_type, account, flush):
+        captured_kwargs.update(
+            dict(
+                source=source,
+                source_type=source_type,
+                account=account,
+                flush=flush,
+            )
+        )
+        return SimpleNamespace(type=source_type, account=account)
+
+    monkeypatch.setattr(
+        "flexmeasures_weather.utils.modeling.get_or_create_source",
+        fake_get_or_create_source,
+    )
+
+    data_source = get_or_create_owm_data_source_for_derived_data()
+
+    assert data_source.type == "forecaster"
+    assert captured_kwargs["account"].name == "Weather"

--- a/flexmeasures_weather/utils/tests/test_modeling.py
+++ b/flexmeasures_weather/utils/tests/test_modeling.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from flexmeasures import Asset
 from flexmeasures import Account
 
+import flexmeasures_weather.utils.modeling as modeling
 from flexmeasures_weather import DEFAULT_WEATHER_STATION_NAME
 from flexmeasures_weather.utils.modeling import (
     SOURCE_TYPE,
@@ -33,12 +34,7 @@ def test_get_or_create_owm_data_source_registers_market_source_on_weather_accoun
     data_source = get_or_create_owm_data_source()
 
     assert data_source.type == "market"
-    if (
-        "account"
-        in inspect.signature(
-            get_or_create_owm_data_source.__globals__["get_or_create_source"]
-        ).parameters
-    ):
+    if "account" in inspect.signature(modeling.get_or_create_source).parameters:
         assert data_source.account is not None
         assert data_source.account.name == data_source.name
     else:
@@ -49,12 +45,7 @@ def test_get_or_create_owm_data_source_for_derived_data_uses_weather_account(fre
     derived_data_source = get_or_create_owm_data_source_for_derived_data()
 
     assert derived_data_source.type == SOURCE_TYPE
-    if (
-        "account"
-        in inspect.signature(
-            get_or_create_owm_data_source.__globals__["get_or_create_source"]
-        ).parameters
-    ):
+    if "account" in inspect.signature(modeling.get_or_create_source).parameters:
         assert derived_data_source.account is not None
         assert derived_data_source.account.name == "Weather"
     else:

--- a/flexmeasures_weather/utils/tests/test_modeling.py
+++ b/flexmeasures_weather/utils/tests/test_modeling.py
@@ -28,12 +28,12 @@ def test_get_or_create_weather_account(fresh_db):
     assert Account.query.filter(Account.name == weather_account.name).count() == 1
 
 
-def test_get_or_create_owm_data_source_registers_market_source_on_weather_account(
+def test_get_or_create_owm_data_source_registers_weather_source_on_weather_account(
     fresh_db,
 ):
     data_source = get_or_create_owm_data_source()
 
-    assert data_source.type == "market"
+    assert data_source.type == SOURCE_TYPE
     if "account" in inspect.signature(modeling.get_or_create_source).parameters:
         assert data_source.account is not None
         assert data_source.account.name == data_source.name
@@ -79,8 +79,8 @@ def test_get_or_create_owm_data_source_passes_weather_account_when_supported(
 
     data_source = get_or_create_owm_data_source()
 
-    assert data_source.type == "market"
-    assert captured_kwargs["account"].name == "Weather"
+    assert data_source.type == SOURCE_TYPE
+    assert captured_kwargs["account"].name == DEFAULT_DATA_SOURCE_NAME
 
 
 def test_get_or_create_owm_derived_data_source_passes_weather_account_when_supported(
@@ -111,4 +111,4 @@ def test_get_or_create_owm_derived_data_source_passes_weather_account_when_suppo
     data_source = get_or_create_owm_data_source_for_derived_data()
 
     assert data_source.type == SOURCE_TYPE
-    assert captured_kwargs["account"].name == "Weather"
+    assert captured_kwargs["account"].name == DEFAULT_DATA_SOURCE_NAME

--- a/flexmeasures_weather/utils/tests/test_modeling.py
+++ b/flexmeasures_weather/utils/tests/test_modeling.py
@@ -72,6 +72,10 @@ def test_get_or_create_owm_data_source_passes_weather_account_when_supported(
         "flexmeasures_weather.utils.modeling.get_or_create_source",
         fake_get_or_create_source,
     )
+    monkeypatch.setattr(
+        "flexmeasures_weather.utils.modeling.SUPPORTS_SOURCE_ACCOUNT",
+        True,
+    )
 
     data_source = get_or_create_owm_data_source()
 
@@ -98,6 +102,10 @@ def test_get_or_create_owm_derived_data_source_passes_weather_account_when_suppo
     monkeypatch.setattr(
         "flexmeasures_weather.utils.modeling.get_or_create_source",
         fake_get_or_create_source,
+    )
+    monkeypatch.setattr(
+        "flexmeasures_weather.utils.modeling.SUPPORTS_SOURCE_ACCOUNT",
+        True,
     )
 
     data_source = get_or_create_owm_data_source_for_derived_data()

--- a/flexmeasures_weather/utils/tests/test_modeling.py
+++ b/flexmeasures_weather/utils/tests/test_modeling.py
@@ -1,12 +1,13 @@
-import inspect
 from types import SimpleNamespace
 
+import pytest
+
 from flexmeasures import Asset
-from flexmeasures import Account
 
 import flexmeasures_weather.utils.modeling as modeling
 from flexmeasures_weather import DEFAULT_DATA_SOURCE_NAME, DEFAULT_WEATHER_STATION_NAME
 from flexmeasures_weather.utils.modeling import (
+    FM_SUPPORTS_ACCOUNT_LINKED_SOURCES,
     SOURCE_TYPE,
     get_or_create_owm_data_source,
     get_or_create_owm_data_source_for_derived_data,
@@ -21,37 +22,54 @@ def test_creating_two_weather_stations(fresh_db):
     assert Asset.query.filter(Asset.name == DEFAULT_WEATHER_STATION_NAME).count() == 2
 
 
+# The version-branch tests below still use monkeypatching to isolate source
+# creation side effects without requiring multiple FlexMeasures installs.
+@pytest.mark.skipif(
+    not FM_SUPPORTS_ACCOUNT_LINKED_SOURCES,
+    reason="Weather source accounts are only supported on FlexMeasures >= 0.32.",
+)
 def test_get_or_create_weather_account(fresh_db):
     weather_account = get_or_create_weather_account()
 
     assert weather_account.name == DEFAULT_DATA_SOURCE_NAME
-    assert Account.query.filter(Account.name == weather_account.name).count() == 1
+    assert (
+        modeling.Account.query.filter(
+            modeling.Account.name == weather_account.name
+        ).count()
+        == 1
+    )
 
 
+@pytest.mark.skipif(
+    not FM_SUPPORTS_ACCOUNT_LINKED_SOURCES,
+    reason="Account-linked weather sources are only supported on FlexMeasures >= 0.32.",
+)
 def test_get_or_create_owm_data_source_registers_weather_source_on_weather_account(
     fresh_db,
 ):
     data_source = get_or_create_owm_data_source()
 
     assert data_source.type == SOURCE_TYPE
-    if "account" in inspect.signature(modeling.get_or_create_source).parameters:
-        assert data_source.account is not None
-        assert data_source.account.name == data_source.name
-    else:
-        assert Account.query.filter(Account.name == data_source.name).count() == 0
+    assert data_source.account is not None
+    assert data_source.account.name == data_source.name
 
 
+@pytest.mark.skipif(
+    not FM_SUPPORTS_ACCOUNT_LINKED_SOURCES,
+    reason="Account-linked weather sources are only supported on FlexMeasures >= 0.32.",
+)
 def test_get_or_create_owm_data_source_for_derived_data_uses_weather_account(fresh_db):
     derived_data_source = get_or_create_owm_data_source_for_derived_data()
 
     assert derived_data_source.type == SOURCE_TYPE
-    if "account" in inspect.signature(modeling.get_or_create_source).parameters:
-        assert derived_data_source.account is not None
-        assert derived_data_source.account.name == "Weather"
-    else:
-        assert Account.query.filter(Account.name == "Weather").count() == 0
+    assert derived_data_source.account is not None
+    assert derived_data_source.account.name == DEFAULT_DATA_SOURCE_NAME
 
 
+@pytest.mark.skipif(
+    not FM_SUPPORTS_ACCOUNT_LINKED_SOURCES,
+    reason="Account-linked weather sources are only supported on FlexMeasures >= 0.32.",
+)
 def test_get_or_create_owm_data_source_passes_weather_account_when_supported(
     fresh_db, monkeypatch
 ):
@@ -72,10 +90,6 @@ def test_get_or_create_owm_data_source_passes_weather_account_when_supported(
         "flexmeasures_weather.utils.modeling.get_or_create_source",
         fake_get_or_create_source,
     )
-    monkeypatch.setattr(
-        "flexmeasures_weather.utils.modeling.SUPPORTS_SOURCE_ACCOUNT",
-        True,
-    )
 
     data_source = get_or_create_owm_data_source()
 
@@ -83,6 +97,10 @@ def test_get_or_create_owm_data_source_passes_weather_account_when_supported(
     assert captured_kwargs["account"].name == DEFAULT_DATA_SOURCE_NAME
 
 
+@pytest.mark.skipif(
+    not FM_SUPPORTS_ACCOUNT_LINKED_SOURCES,
+    reason="Account-linked weather sources are only supported on FlexMeasures >= 0.32.",
+)
 def test_get_or_create_owm_derived_data_source_passes_weather_account_when_supported(
     fresh_db, monkeypatch
 ):
@@ -103,12 +121,74 @@ def test_get_or_create_owm_derived_data_source_passes_weather_account_when_suppo
         "flexmeasures_weather.utils.modeling.get_or_create_source",
         fake_get_or_create_source,
     )
-    monkeypatch.setattr(
-        "flexmeasures_weather.utils.modeling.SUPPORTS_SOURCE_ACCOUNT",
-        True,
-    )
 
     data_source = get_or_create_owm_data_source_for_derived_data()
 
     assert data_source.type == SOURCE_TYPE
     assert captured_kwargs["account"].name == DEFAULT_DATA_SOURCE_NAME
+
+
+@pytest.mark.skipif(
+    FM_SUPPORTS_ACCOUNT_LINKED_SOURCES,
+    reason="Legacy source creation without accounts is only used on FlexMeasures < 0.32.",
+)
+def test_get_or_create_owm_data_source_omits_account_when_not_supported(monkeypatch):
+    captured_kwargs = {}
+
+    def fake_get_or_create_source(source, source_type, flush):
+        captured_kwargs.update(
+            dict(
+                source=source,
+                source_type=source_type,
+                flush=flush,
+            )
+        )
+        return SimpleNamespace(type=source_type, name=source)
+
+    monkeypatch.setattr(
+        "flexmeasures_weather.utils.modeling.get_or_create_source",
+        fake_get_or_create_source,
+    )
+
+    data_source = get_or_create_owm_data_source()
+
+    assert data_source.type == SOURCE_TYPE
+    assert captured_kwargs == {
+        "source": DEFAULT_DATA_SOURCE_NAME,
+        "source_type": SOURCE_TYPE,
+        "flush": False,
+    }
+
+
+@pytest.mark.skipif(
+    FM_SUPPORTS_ACCOUNT_LINKED_SOURCES,
+    reason="Legacy source creation without accounts is only used on FlexMeasures < 0.32.",
+)
+def test_get_or_create_owm_derived_data_source_omits_account_when_not_supported(
+    monkeypatch,
+):
+    captured_kwargs = {}
+
+    def fake_get_or_create_source(source, source_type, flush):
+        captured_kwargs.update(
+            dict(
+                source=source,
+                source_type=source_type,
+                flush=flush,
+            )
+        )
+        return SimpleNamespace(type=source_type, name=source)
+
+    monkeypatch.setattr(
+        "flexmeasures_weather.utils.modeling.get_or_create_source",
+        fake_get_or_create_source,
+    )
+
+    data_source = get_or_create_owm_data_source_for_derived_data()
+
+    assert data_source.type == SOURCE_TYPE
+    assert captured_kwargs == {
+        "source": f"FlexMeasures {DEFAULT_DATA_SOURCE_NAME}",
+        "source_type": SOURCE_TYPE,
+        "flush": False,
+    }

--- a/flexmeasures_weather/utils/weather.py
+++ b/flexmeasures_weather/utils/weather.py
@@ -198,7 +198,7 @@ def call_api(
         Exception: If an invalid weather provider is configured.
     """
 
-    provider = str(current_app.config.get("WEATHER_PROVIDER", ""))
+    provider = str(current_app.config.get("WEATHER_PROVIDER", "OWM"))
     if provider not in ["OWM", "WAPI"]:
         raise Exception(
             "Invalid provider name. Please set WEATHER_PROVIDER setting in config file to either OWM or WAPI, the two permissible options."


### PR DESCRIPTION
## Summary
- register a dedicated account for the weather provider data source
- create the raw weather provider source with the version-aware weather source type (`forecaster` on newer FlexMeasures, `forecasting script` on older versions)
- keep derived FlexMeasures weather data under the same version-aware source type
- branch account-linked source setup explicitly on `FlexMeasures >= 0.32`
- add tests covering account registration and source creation behavior across the version branches

## Manual Testing
- checked out `flexmeasures` branch `feat/sensor-data-source-filtering`
- installed local `flexmeasures` and `flexmeasures-weather` in the same virtualenv
- ran `flexmeasures db upgrade` against the target database
- enabled required PostgreSQL extensions: `cube` and `earthdistance`
- ran:
  - `flexmeasures weather register-weather-sensor --name "temperature" --latitude 30 --longitude 40`
  - `flexmeasures weather register-weather-sensor --name "wind speed" --latitude 30 --longitude 40`
  - `flexmeasures weather register-weather-sensor --name "irradiance" --latitude 30 --longitude 40`
  - `flexmeasures weather get-weather-forecasts --location 30,40`
- verified the command completed successfully and forecasts were saved
- verified in the database/app shell that:
  - account `OpenWeatherMap` exists
  - source `OpenWeatherMap` exists with type `forecaster` and is linked to the `OpenWeatherMap` account
  - source `FlexMeasures OpenWeatherMap` exists with type `forecaster` and is linked to the same account

closes #12
